### PR TITLE
タスクに関するシステムスペックを修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    title { 'Task' }
+    title { 'title' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
     association :project
+
     trait :done do
       status { :done }
       completion_date { Time.current.yesterday }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :done_yesterday do
+      status { 'done' }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
-
+    association :project
     trait :done do
       status { :done }
       completion_date { Time.current.yesterday }

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
 
-    trait :done_yesterday do
-      status { 'done' }
+    trait :done do
+      status { :done }
       completion_date { Time.current.yesterday }
     end
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    title { 'title' }
+    title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Task', type: :system do
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
+        expect(find('.task_list')).to have_content(short_time(Time.current))
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Task', type: :system do
     let(:project){ create(:project) }
     let(:task){ create(:task, project_id: project.id) }
     context '正常系' do
-      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること', focus:true do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXED: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
@@ -98,11 +98,11 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task削除' do
+    let(:project){ create(:project) }
+    let!(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -61,15 +61,15 @@ RSpec.describe 'Task', type: :system do
     let(:project){ create(:project) }
     let(:task){ create(:task, project_id: project.id) }
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
-        # FIXME: テストが失敗するので修正してください
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること', focus:true do
+        # FIXED: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
+    let(:project){ create(:project) }
+    let(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+        # DONE: ローカル変数ではなく let を使用してください
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
@@ -15,10 +15,10 @@ RSpec.describe 'Task', type: :system do
 
       xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
+          puts project.id
         click_link 'View Todos'
+          puts task.project_id
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
@@ -27,10 +27,10 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task新規作成' do
+    let(:project){ create(:project) }
     context '正常系' do
       it 'Taskが新規作成されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
+        # DONE: ローカル変数ではなく let を使用してください
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
@@ -43,11 +43,11 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task詳細' do
+    let(:project){ create(:project) }
+    let(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       it 'Taskが表示されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+        # DONE: ローカル変数ではなく let を使用してください
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -58,6 +58,8 @@ RSpec.describe 'Task', type: :system do
   end
 
   describe 'Task編集' do
+    let(:project){ create(:project) }
+    let(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
@@ -72,9 +74,7 @@ RSpec.describe 'Task', type: :system do
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
-        # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+        # DONE: ローカル変数ではなく let を使用してください
         visit edit_project_task_path(project, task)
         select 'done', from: 'Status'
         click_button 'Update Task'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,12 +13,11 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
-        # FIXME: テストが失敗するので修正してください
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+        # FIXED: テストが失敗するので修正してください
         visit project_path(project)
-          puts project.id
         click_link 'View Todos'
-          puts task.project_id
+        switch_to_window(windows.last)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
     let(:project){ create(:project) }
-    let(:task){ create(:task, project_id: project.id) }
+    let!(:task){ create(:task, project_id: project.id) }
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # DONE: ローカル変数ではなく let を使用してください

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Task', type: :system do
   describe 'Task編集' do
     let(:project){ create(:project) }
     let(:task){ create(:task, project_id: project.id) }
-    let(:task_done_yesterday){ create(:task, :done_yesterday, project_id: project.id) }
+    let(:task_done){ create(:task, :done, project_id: project.id) }
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXED: テストが失敗するので修正してください
@@ -83,12 +83,12 @@ RSpec.describe 'Task', type: :system do
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # DONE: FactoryBotのtraitを利用してください
-        visit edit_project_task_path(project, task_done_yesterday)
+        visit edit_project_task_path(project, task_done)
         select 'todo', from: 'Status'
         click_button 'Update Task'
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
-        expect(current_path).to eq project_task_path(project, task_done_yesterday)
+        expect(current_path).to eq project_task_path(project, task_done)
       end
     end
   end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Task', type: :system do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(find('.task_list')).not_to have_content task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -60,11 +60,10 @@ RSpec.describe 'Task', type: :system do
   describe 'Task編集' do
     let(:project){ create(:project) }
     let(:task){ create(:task, project_id: project.id) }
+    let(:task_done_yesterday){ create(:task, :done_yesterday, project_id: project.id) }
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXED: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
@@ -84,15 +83,13 @@ RSpec.describe 'Task', type: :system do
       end
 
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
-        # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
-        visit edit_project_task_path(project, task)
+        # DONE: FactoryBotのtraitを利用してください
+        visit edit_project_task_path(project, task_done_yesterday)
         select 'todo', from: 'Status'
         click_button 'Update Task'
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
-        expect(current_path).to eq project_task_path(project, task)
+        expect(current_path).to eq project_task_path(project, task_done_yesterday)
       end
     end
   end
@@ -101,7 +98,7 @@ RSpec.describe 'Task', type: :system do
     let(:project){ create(:project) }
     let!(:task){ create(:task, project_id: project.id) }
     context '正常系' do
-      # FIXME: テストが失敗するので修正してください
+      # FIXED: テストが失敗するので修正してください
       it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Task', type: :system do
   describe 'Task一覧' do
     let(:project){ create(:project) }
-    let!(:task){ create(:task, project_id: project.id) }
+    let!(:task){ create(:task) }
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # DONE: ローカル変数ではなく let を使用してください
@@ -43,7 +43,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task詳細' do
     let(:project){ create(:project) }
-    let(:task){ create(:task, project_id: project.id) }
+    let(:task){ create(:task) }
     context '正常系' do
       it 'Taskが表示されること' do
         # DONE: ローカル変数ではなく let を使用してください
@@ -58,8 +58,8 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     let(:project){ create(:project) }
-    let(:task){ create(:task, project_id: project.id) }
-    let(:task_done){ create(:task, :done, project_id: project.id) }
+    let(:task){ create(:task) }
+    let(:task_done){ create(:task, :done) }
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXED: テストが失敗するので修正してください
@@ -95,7 +95,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task削除' do
     let(:project){ create(:project) }
-    let!(:task){ create(:task, project_id: project.id) }
+    let!(:task){ create(:task) }
     context '正常系' do
       # FIXED: テストが失敗するので修正してください
       it 'Taskが削除されること' do


### PR DESCRIPTION
## 問題点
1つ目のテスト「一覧ページにアクセスした場合、Taskが表示されること」で解決できなかった問題点が1つあります。
ファクトリで作成したタスクのタイトルがTaskであるためテストはパスしていますが、作成されたタスクがタスク一覧ページに表示されていません。

## 確認したこと
タスクが作成されていること、作成されたタスクとプロジェクトが紐付いていること、新しいウィンドウが開いていないことなどは確認しました。

## `expect(page).to have_content task.title`直後のスクリーンショット
[![Image from Gyazo](https://i.gyazo.com/9298e5ed486c719fb2619c3d75f81a23.png)](https://gyazo.com/9298e5ed486c719fb2619c3d75f81a23)